### PR TITLE
Updating to use TF Serving 1.6 from copr RPM package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ LABEL io.k8s.description="Tensorflow serving builder" \
 RUN yum install -y tree which \
 	&& yum clean all -y
 
+RUN wget -O /etc/yum.repos.d/tf-model-server.repo https://copr.fedorainfracloud.org/coprs/croberts/tensorflow-model-server/repo/epel-7/croberts-tensorflow-model-server-epel-7.repo \
+    && yum install -y tensorflow-model-server \
+    && yum clean all -y
+
 COPY ./s2i/bin/ /usr/libexec/s2i
 
 #Drop the root user and make the content of /opt/app-root owned by user 1001
@@ -19,8 +23,6 @@ RUN chown -R 1001:1001 /opt/app-root
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001
-COPY ./tensorflow_model_server /opt/app-root/tensorflow_model_server
-
 
 # EXPOSE 6006
 

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -15,4 +15,4 @@ pwd
 
 echo " -----> Run tenserflow server."
 
-exec /opt/app-root/tensorflow_model_server --port=6006 --model_name=mnist --model_base_path=/opt/app-root/src/
+exec /usr/bin/tensorflow_model_server --port=6006 --model_name=mnist --model_base_path=/opt/app-root/src/


### PR DESCRIPTION
Use RPM package and eliminates the git-committed binary.